### PR TITLE
ajout info avis ne correspond pas à la situation la plus récente

### DIFF
--- a/test/resources/postHttpResponseErreurCorrectif.txt
+++ b/test/resources/postHttpResponseErreurCorrectif.txt
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+	
+<head>
+<meta http-equiv="Content-type" content="text/html; charset=UTF-8" />
+
+<title>Impots.gouv.fr - Service de vérification en ligne des avis</title>
+<link href="/secavis/css/style.css" rel="styleSheet" type="text/css" />
+</head>
+
+<body>
+
+<div id="conteneur">
+<div id="barre_haut">
+			<div style="float: left;"><img src="/secavis/img/bo_seule-2.gif" alt="" /></div>
+			<div style="float: right;"><img src="/secavis/img/bo_seule-3.gif" alt="" /></div>
+</div>
+<div id="principal">
+<div id="nav_pro">
+<b>L'administration fiscale certifie l'authenticité du document présenté pour les données suivantes :</b>
+</div>
+
+<div class="titre_affiche_avis">
+<span>Impôt   2018 sur les revenus de l'année  2017  
+</span>
+</div>		
+		
+
+			<table>
+				<tbody>
+				<tr>
+					<td class="label">
+					</td>
+					<td class="label">Déclarant 1
+					</td>
+					<td class="label">Déclarant 2
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair">Nom
+					</td>
+					<td class="labelPair">MARTIN
+					</td>
+					<td class="labelPair">
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair">Nom de naissance
+					</td>
+					<td class="labelImpair">MARTIN
+					</td>
+					<td class="labelImpair">
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair">Prénom(s)
+					</td>
+					<td class="labelPair">Jean
+					</td>
+					<td class="labelPair">
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair">Date de naissance
+					</td>
+					<td class="labelImpair">29/03/1984
+					</td>
+					<td class="labelImpair">
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair">
+						Adresse déclarée au 1<sup>er</sup> janvier  2015
+					</td>
+					<td class="labelPair">34 RUE DE L'EGLISE
+					</td>
+					<td class="labelPair">
+					</td>
+				</tr>
+					<tr>
+					<td class="labelPair">
+					</td>
+					<td colspan="2" class="labelPair">75009 PARIS
+					</td>
+					</tr>			
+				<tr>
+					<td class="espace"></td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Date de mise en recouvrement de l'avis d'impôt
+					</td>
+					<td class="textPair">31/07/2015
+					</td>
+				</tr>		
+				<tr>
+					<td class="labelImpair" colspan="2">Date d'établissement
+					</td>
+					<td class="textImpair">08/07/2015
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Nombre de part(s)
+					</td>
+					<td class="textPair">1.00
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair" colspan="2">Situation de famille
+					</td>
+					<td class="textImpair">Célibataire
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Nombre de personne(s) à charge
+					</td>
+					<td class="textPair">0
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair" colspan="2">Revenu brut global
+					</td>
+					<td class="textImpair">17 580 €
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Revenu imposable
+					</td>
+					<td class="textPair">17 580 €
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair" colspan="2">Impôt sur le revenu net avant corrections
+					</td>
+					<td class="textImpair">1 665 €
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Montant de l'impôt
+					</td>
+					<td class="textPair">1 665 €
+					</td>
+				</tr>								
+				<tr>
+					<td class="labelImpair" colspan="2">Revenu fiscal de référence
+					</td>
+					<td class="textImpair">17 580 €
+					</td>
+				</tr>							
+
+			</tbody></table>
+			
+			<div id="situationPartielle">
+			</div>
+				
+			<div id="erreurCorrectif">Ce document ne correspond pas à la situation<br />la plus récente pour cet usager
+			</div>
+			
+			<div id="boutonsAvis">		
+				<a class="nouvelle_recherche" href="/secavis/">			
+					Nouvelle recherche				
+				</a>
+			 </div>
+
+		</div>
+		<div id="bas_page">© Ministère de l'Économie et des Finances</div><img src="https://logs1279.xiti.com/hit.xiti?s=532158&amp;s2=3&amp;p=AFFICHAGE::Avis_Avec_Correctif_erreur_pas_javascript&amp;" alt="" height="1" width="1" />
+	</div>
+</body>
+</html>

--- a/test/resources/postHttpResponseSituationPartielle.txt
+++ b/test/resources/postHttpResponseSituationPartielle.txt
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+	
+<head>
+<meta http-equiv="Content-type" content="text/html; charset=UTF-8" />
+
+<title>Impots.gouv.fr - Service de vérification en ligne des avis</title>
+<link href="/secavis/css/style.css" rel="styleSheet" type="text/css" />
+</head>
+
+<body>
+
+<div id="conteneur">
+<div id="barre_haut">
+			<div style="float: left;"><img src="/secavis/img/bo_seule-2.gif" alt="" /></div>
+			<div style="float: right;"><img src="/secavis/img/bo_seule-3.gif" alt="" /></div>
+</div>
+<div id="principal">
+<div id="nav_pro">
+<b>L'administration fiscale certifie l'authenticité du document présenté pour les données suivantes :</b>
+</div>
+
+<div class="titre_affiche_avis">
+<span>Impôt   2018 sur les revenus de l'année  2017  (*)
+</span>
+</div>		
+		
+
+			<table>
+				<tbody>
+				<tr>
+					<td class="label">
+					</td>
+					<td class="label">Déclarant 1
+					</td>
+					<td class="label">Déclarant 2
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair">Nom
+					</td>
+					<td class="labelPair">MARTIN
+					</td>
+					<td class="labelPair">
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair">Nom de naissance
+					</td>
+					<td class="labelImpair">MARTIN
+					</td>
+					<td class="labelImpair">
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair">Prénom(s)
+					</td>
+					<td class="labelPair">Jean
+					</td>
+					<td class="labelPair">
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair">Date de naissance
+					</td>
+					<td class="labelImpair">29/03/1984
+					</td>
+					<td class="labelImpair">
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair">
+						Adresse déclarée au 1<sup>er</sup> janvier  2015
+					</td>
+					<td class="labelPair">34 RUE DE L'EGLISE
+					</td>
+					<td class="labelPair">
+					</td>
+				</tr>
+					<tr>
+					<td class="labelPair">
+					</td>
+					<td colspan="2" class="labelPair">75009 PARIS
+					</td>
+					</tr>			
+				<tr>
+					<td class="espace"></td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Date de mise en recouvrement de l'avis d'impôt
+					</td>
+					<td class="textPair">31/07/2015
+					</td>
+				</tr>		
+				<tr>
+					<td class="labelImpair" colspan="2">Date d'établissement
+					</td>
+					<td class="textImpair">08/07/2015
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Nombre de part(s)
+					</td>
+					<td class="textPair">1.00
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair" colspan="2">Situation de famille
+					</td>
+					<td class="textImpair">Célibataire
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Nombre de personne(s) à charge
+					</td>
+					<td class="textPair">0
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair" colspan="2">Revenu brut global
+					</td>
+					<td class="textImpair">17 580 €
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Revenu imposable
+					</td>
+					<td class="textPair">17 580 €
+					</td>
+				</tr>
+				<tr>
+					<td class="labelImpair" colspan="2">Impôt sur le revenu net avant corrections
+					</td>
+					<td class="textImpair">1 665 €
+					</td>
+				</tr>
+				<tr>
+					<td class="labelPair" colspan="2">Montant de l'impôt
+					</td>
+					<td class="textPair">1 665 €
+					</td>
+				</tr>								
+				<tr>
+					<td class="labelImpair" colspan="2">Revenu fiscal de référence
+					</td>
+					<td class="textImpair">17 580 €
+					</td>
+				</tr>							
+
+			</tbody></table>
+			
+			<div id="situationPartielle">(*) Situation  2015  partielle
+			</div>
+				
+			<div id="boutonsAvis">		
+				<a class="nouvelle_recherche" href="/secavis/">			
+					Nouvelle recherche				
+				</a>
+			 </div>
+
+		</div>
+		<div id="bas_page">© Ministère de l'Économie et des Finances</div><img src="https://logs1279.xiti.com/hit.xiti?s=532158&amp;s2=3&amp;p=AFFICHAGE::Avis_Sans_Correctif_erreur_pas_javascript&amp;" alt="" height="1" width="1" />
+	</div>
+</body>
+</html>

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -146,9 +146,9 @@ module.exports.result = function parseResult(html, year, callback) {
     var textNode = _.filter(nodeSituationPartielle[0].childNodes, { nodeType: 3 });
     textNode.forEach(function(value, index, array) {
       if (index === 0) {
-        result.nodeSituationPartielle = value.data;
+        result.situationPartielle = value.data;
       } else {
-        result.nodeSituationPartielle += ' ' + value.data;
+        result.situationPartielle += ' ' + value.data;
       }
     });
   }

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -131,8 +131,26 @@ module.exports.result = function parseResult(html, year, callback) {
 
   var nodeErreurCorrectif = select('//*[@id="erreurCorrectif"]', doc);
   if (nodeErreurCorrectif.length > 0) {
-    var erreurCorrectif = nodeErreurCorrectif[0].firstChild.data + ' ' + nodeErreurCorrectif[0].lastChild.data;
-    result.erreurCorrectif = erreurCorrectif;
+    var textNode = _.filter(nodeErreurCorrectif[0].childNodes, { nodeType: 3 });
+    textNode.forEach(function(value, index, array) {
+      if (index === 0) {
+        result.erreurCorrectif = value.data;
+      } else {
+        result.erreurCorrectif += ' ' + value.data;
+      }
+    });
+  }
+
+  var nodeSituationPartielle = select('//*[@id="situationPartielle"]', doc);
+  if (nodeSituationPartielle.length > 0) {
+    var textNode = _.filter(nodeSituationPartielle[0].childNodes, { nodeType: 3 });
+    textNode.forEach(function(value, index, array) {
+      if (index === 0) {
+        result.nodeSituationPartielle = value.data;
+      } else {
+        result.nodeSituationPartielle += ' ' + value.data;
+      }
+    });
   }
 
   if(!result.declarant1.nom) {

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -128,6 +128,13 @@ module.exports.result = function parseResult(html, year, callback) {
     result.anneeImpots = regexp.exec(titleAnnee)[0];
     result.anneeRevenus = regexp.exec(titleAnnee)[0];
   }
+
+  var nodeErreurCorrectif = select('//*[@id="erreurCorrectif"]', doc);
+  if (nodeErreurCorrectif.length > 0) {
+    var erreurCorrectif = nodeErreurCorrectif[0].firstChild.data + ' ' + nodeErreurCorrectif[0].lastChild.data;
+    result.erreurCorrectif = erreurCorrectif;
+  }
+
   if(!result.declarant1.nom) {
     return callback(new Error("Parsing error"))
   }


### PR DESCRIPTION
Pour certain avis, SVAIR précise que le document ne correspond pas à la situation<br />la plus récente pour cet usager.
La modification proposée permet de récupérer cette donnée si elle est présente.